### PR TITLE
Retornando 200 cuando no hay visitas programadas en x fecha en vez de… CD

### DIFF
--- a/backend/ventas_servicio/gestor_ventas/aplicacion/lecturas/ruta_visitas.py
+++ b/backend/ventas_servicio/gestor_ventas/aplicacion/lecturas/ruta_visitas.py
@@ -46,9 +46,8 @@ def consultar_ruta_visita():
 
     if not visitas:
         return jsonify({
-            "error": "Ruta no encontrada",
-            "detalles": f"No se encontró una ruta para el vendedor {vendedor_id} en la fecha {fecha}"
-        }), 404
+           "ruta_visita": []
+        }), 200
 
     # Serialize the data using the schema
     schema = RutaVisitasInputSchema(many=True)

--- a/backend/ventas_servicio/gestor_ventas/aplicacion/lecturas/rutas_visitas_optimizada.py
+++ b/backend/ventas_servicio/gestor_ventas/aplicacion/lecturas/rutas_visitas_optimizada.py
@@ -46,9 +46,8 @@ def consultar_ruta_visita_optimizada():
     visitas = repo.obtener_rutas_por_vendedor_y_fecha(vendedor_id, fecha)
     if not visitas:
         return jsonify({
-            "error": "Ruta no encontrada",
-            "detalles": f"No se encontró una ruta para el vendedor {vendedor_id} en la fecha {fecha}"
-        }), 404
+           "ruta_visita": []
+        }), 200
 
     ruta_optimizada = optimizar_ruta(visitas)
     # Serialize the data using the schema

--- a/backend/ventas_servicio/gestor_ventas/tests/test_ruta_visita.py
+++ b/backend/ventas_servicio/gestor_ventas/tests/test_ruta_visita.py
@@ -100,11 +100,9 @@ class TestRutaVisita(unittest.TestCase):
         response = self.client.get(
             "/ruta_visita?vendedor_id=1&fecha=2023-10-01", headers=headers
         )
-        self.assertEqual(response.status_code, 404)
-        self.assertEqual(response.json, {
-            "error": "Ruta no encontrada",
-            "detalles": "No se encontró una ruta para el vendedor 1 en la fecha 2023-10-01",
-        })
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json, {"ruta_visita": []})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/ventas_servicio/gestor_ventas/tests/test_ruta_visita_optimizada.py
+++ b/backend/ventas_servicio/gestor_ventas/tests/test_ruta_visita_optimizada.py
@@ -92,6 +92,5 @@ class TestConsultarRutaVisitaOptimizada(unittest.TestCase):
         response = self.client.get("/ruta_visita_optimizada", headers=headers, query_string=query_string)
 
         # Assert
-        self.assertEqual(response.status_code, 404)
-        self.assertIn("error", response.json)
-        self.assertEqual(response.json["error"], "Ruta no encontrada")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json, {"ruta_visita": []})


### PR DESCRIPTION
… 404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated API endpoints to return a 200 status with an empty "ruta_visita" list when no visit routes are found, instead of a 404 error.
- **Tests**
	- Adjusted test cases to expect a 200 status and an empty list for scenarios where no visit routes are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->